### PR TITLE
Remove UIWebview reference. Deprecated

### DIFF
--- a/Sources/SwipeTransition/SwipeToDismiss/SwipeToDismissController.swift
+++ b/Sources/SwipeTransition/SwipeToDismiss/SwipeToDismissController.swift
@@ -106,8 +106,7 @@ extension SwipeToDismissController: UIGestureRecognizerDelegate {
             if scrollViewType === UIScrollView.self // filter UITableViewWrapperView and so on...
                 || scrollViewType === UITableView.self
                 || scrollViewType === UICollectionView.self
-                || superViewType === WKWebView.self
-                || superViewType === UIWebView.self {
+                || superViewType === WKWebView.self {
                     context.observedScrollView = scrollView
             } else {
                 gestureRecognizer.state = .failed


### PR DESCRIPTION
**Description**

UIWebview is deprecated. ITMS-90809: Deprecated API Usage - Apple will stop accepting submissions of apps that use UIWebView APIs . See [documentation](https://developer.apple.com/documentation/uikit/uiwebview) for more information.

**Fixes**

Remove reference to UIWebview
